### PR TITLE
Tensorflow 2.0 Upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,6 @@ RETAIN has shown to be highly effective for creating predictive models for a mul
 * Simpler Keras code with Tensorflow backend
 * Ability to use extra numeric inputs of fixed size that can hold numeric information about the patients visit such as patient's age, quantity of drug prescribed, or blood pressure
 * Improved embedding logic that avoids using large dense inputs
-* Ability to create multi-gpu models (experimental)
-* Switch to CuDNN implementations of RNN layers that provides immense training speed ups
 * Ability to evaluate models during training
 * Ability to train models with only positive contributions which improves performance
 * Extra script to evaluate the model and output several helper graphics
@@ -22,17 +20,11 @@ RETAIN has shown to be highly effective for creating predictive models for a mul
 ### Requirements
 0. Python 3
 1. If using GPU: CUDA and CuDNN
-2. Tensorflow 1.13.1
-3. Keras 2.1.3
-4. Scikit-Learn
-5. Numpy
-6. Pandas
-7. Matplotlib (evaluation)
-8. [Keras-experiments by Alex Volkov](https://github.com/avolkov1/keras_experiments):
-
-    pip install git+https://github.com/avolkov1/keras_experiments/
-
-    Enables multi-gpu support with reliable savings of the model
+2. Tensorflow 2.0+
+3. Scikit-Learn
+4. Numpy
+5. Pandas
+6. Matplotlib (evaluation)
 
 ## Installation
 1. Clone down the repository
@@ -64,9 +56,9 @@ retain_train.py has multiple arguments to customize the training and model:
 * `--batch_size`: Integer Batch Size for training. Default: 32
 * `--dropout_input`: Float Dropout rate for embedding of codes and numeric features (0 to 1). Default: 0.0
 * `--dropout_context`: Float Dropout rate for context vector (0 to 1). Default: 0.0
-* `--l2`: Float L2 regularitzation value for layers. Default: 0.0
+* `--l2`: Float L2 regularization value for layers. Default: 0.0
 * `--directory`: String Directory to save the model and the log file to. Default: 'Model' (directory needs to exist otherwise error will be thrown)
-* `--allow_negative`: Allows negative weights for embeddings/attentions (original RETAIN implementaiton allows it but forcing non-negative weights have shown to perform better on a range of tasks). Default: off
+* `--allow_negative`: Allows negative weights for embeddings/attentions (original RETAIN implementation allows it but forcing non-negative weights have shown to perform better on a range of tasks). Default: off
 
 ## Evaluation Arguments
 

--- a/process_mimic_modified.py
+++ b/process_mimic_modified.py
@@ -1,8 +1,8 @@
 # This script processes MIMIC-III dataset and builds longitudinal diagnosis records for patients with at 2+ visits.
 # The output data are 4 pickled pandas dataframes suitable for training RETAIN-Keras
-# Orginally Written by Edward Choi (mp2893@gatech.edu) https://github.com/mp2893/retain
+# Originally Written by Edward Choi (mp2893@gatech.edu) https://github.com/mp2893/retain
 # Modified by Timothy Rosenflanz (timothy.rosenflanz@optum.com) to work with RETAIN-Keras
-# Usage: Put this script to the foler where MIMIC-III CSV files are located. Then execute the below command.
+# Usage: Put this script to the folder where MIMIC-III CSV files are located. Then execute the below command.
 # python process_mimic_modified.py ADMISSIONS.csv DIAGNOSES_ICD.csv PATIENTS.csv <output directory> <train data proportion>
 
 # Output files
@@ -10,8 +10,8 @@
 # data_test.pkl: Pickled dataframe used for testing containing the codes and to_event sequences as specified in the README
 # data_train_3digit.pkl: Pickled dataframe used for training containing the 3 digit codes and to_event sequences as specified in the README
 # data_test_3digit.pkl: Pickled dataframe used for testing containing the 3 digit codes and to_event sequences as specified in the README
-# target_train.pkl: Pickled dataframe containing target lables for training as specified in the README
-# target_test.pkl: Pickled dataframe containing target lables for testing as specified in the README
+# target_train.pkl: Pickled dataframe containing target labels for training as specified in the README
+# target_test.pkl: Pickled dataframe containing target labels for testing as specified in the README
 # dictionary.pkl: Python dictionary that maps string diagnosis codes to integer diagnosis codes.
 # dictionary_3digit.pkl: Python dictionary that maps string diagnosis codes to integer 3 digit diagnosis codes.
 

--- a/retain_evaluation.py
+++ b/retain_evaluation.py
@@ -7,24 +7,22 @@ from sklearn.metrics import roc_auc_score, average_precision_score,\
 from sklearn.calibration import calibration_curve
 import matplotlib.pyplot as plt
 import tensorflow as tf
-import keras.backend as K
-from keras.models import load_model
-from keras.preprocessing import sequence
-from keras.constraints import Constraint
-from keras.utils.data_utils import Sequence
-from keras_exp.multigpu import get_available_gpus, make_parallel
+import tensorflow.keras.backend as K
+from tensorflow.keras.models import load_model
+from tensorflow.keras.preprocessing import sequence
+from tensorflow.keras.constraints import Constraint
+from tensorflow.keras.utils import Sequence
 
 def import_model(path):
     """Import model from given path and assign it to appropriate devices"""
     K.clear_session()
-    config = tf.ConfigProto(allow_soft_placement=True, log_device_placement=False)
+    config = tf.compat.v1.ConfigProto(allow_soft_placement=True, log_device_placement=False)
     config.gpu_options.allow_growth = True
-    tfsess = tf.Session(config=config)
-    K.set_session(tfsess)
+    tfsess = tf.compat.v1.Session(config=config)
+    tf.compat.v1.keras.backend.set_session(tfsess)
     model = load_model(path, custom_objects={'FreezePadding':FreezePadding,
                                              'FreezePadding_Non_Negative':FreezePadding_Non_Negative})
-    if len(get_available_gpus()) > 1:
-        model = make_parallel(model)
+
     return model
 
 def get_model_parameters(model):

--- a/retain_interpretations.py
+++ b/retain_interpretations.py
@@ -4,23 +4,23 @@ import pickle as pickle
 import numpy as np
 import pandas as pd
 import tensorflow as tf
-import keras.backend as K
-from keras.models import load_model, Model
-from keras.preprocessing import sequence
-from keras.constraints import Constraint
-from keras.utils.data_utils import Sequence
+import tensorflow.keras.backend as K
+from tensorflow.keras.models import load_model, Model
+from tensorflow.keras.preprocessing import sequence
+from tensorflow.keras.constraints import Constraint
+from tensorflow.keras.utils import Sequence
 
 def import_model(path):
     """Import model from given path and assign it to appropriate devices"""
     K.clear_session()
-    config = tf.ConfigProto(allow_soft_placement=True, log_device_placement=False)
+    config = tf.compat.v1.ConfigProto(allow_soft_placement=True, log_device_placement=False)
     config.gpu_options.allow_growth = True
-    tfsess = tf.Session(config=config)
-    K.set_session(tfsess)
+    tfsess = tf.compat.v1.Session(config=config)
+    tf.compat.v1.keras.backend.set_session(tfsess)
     model = load_model(path, custom_objects={'FreezePadding':FreezePadding,
                                              'FreezePadding_Non_Negative':FreezePadding_Non_Negative})
     model_with_attention = Model(model.inputs, model.outputs +\
-                                              [model.get_layer(name='softmax_1').output,\
+                                              [model.get_layer(name='softmax_1').output,
                                                model.get_layer(name='beta_dense_0').output])
     return model, model_with_attention
 
@@ -217,7 +217,6 @@ def main(ARGS):
     model_parameters = get_model_parameters(model)
     print('Reading Data')
     data, dictionary = read_data(model_parameters, ARGS.path_data, ARGS.path_dictionary)
-    data_generator = SequenceBuilder(data, model_parameters, ARGS)
     probabilities = get_predictions(model, data, model_parameters, ARGS)
     ARGS.batch_size = 1
     data_generator = SequenceBuilder(data, model_parameters, ARGS)

--- a/retain_interpretations.py
+++ b/retain_interpretations.py
@@ -20,7 +20,7 @@ def import_model(path):
     model = load_model(path, custom_objects={'FreezePadding':FreezePadding,
                                              'FreezePadding_Non_Negative':FreezePadding_Non_Negative})
     model_with_attention = Model(model.inputs, model.outputs +\
-                                              [model.get_layer(name='softmax_1').output,
+                                              [model.get_layer(name='softmax_1').output,\
                                                model.get_layer(name='beta_dense_0').output])
     return model, model_with_attention
 

--- a/retain_train.py
+++ b/retain_train.py
@@ -190,7 +190,7 @@ def model_create(ARGS):
         #Compute alpha, visit attention
         alpha_out = alpha(time_embs)
         alpha_out = L.TimeDistributed(alpha_dense, name='alpha_dense_0')(alpha_out)
-        alpha_out = L.Softmax(axis=1)(alpha_out)
+        alpha_out = L.Softmax(name='softmax_1', axis=1)(alpha_out)
         #Compute beta, codes attention
         beta_out = beta(time_embs)
         beta_out = L.TimeDistributed(beta_dense, name='beta_dense_0')(beta_out)

--- a/retain_train.py
+++ b/retain_train.py
@@ -4,15 +4,14 @@ import argparse
 import numpy as np
 import pandas as pd
 import tensorflow as tf
-import keras.layers as L
-from keras import backend as K
-from keras.models import Model
-from keras.callbacks import ModelCheckpoint, Callback
-from keras.preprocessing import sequence
-from keras.utils.data_utils import Sequence
-from keras.regularizers import l2
-from keras.constraints import non_neg, Constraint
-from keras_exp.multigpu import get_available_gpus, make_parallel
+import tensorflow.keras.layers as L
+from tensorflow.keras import backend as K
+from tensorflow.keras.models import Model
+from tensorflow.keras.callbacks import ModelCheckpoint, Callback
+from tensorflow.keras.preprocessing import sequence
+from tensorflow.keras.utils import Sequence
+from tensorflow.keras.regularizers import l2
+from tensorflow.keras.constraints import non_neg, Constraint
 from sklearn.metrics import roc_auc_score, average_precision_score, precision_recall_curve
 
 
@@ -142,10 +141,6 @@ def model_create(ARGS):
             output_constraint = non_neg()
 
 
-
-        #Get available gpus , returns empty list if none
-        glist = get_available_gpus()
-
         def reshape(data):
             """Reshape the context vectors to 3D vector"""
             return K.reshape(x=data, shape=(K.shape(data)[0], 1, reshape_size))
@@ -156,8 +151,7 @@ def model_create(ARGS):
         #Calculate embedding for each code and sum them to a visit level
         codes_embs_total = L.Embedding(ARGS.num_codes+1,
                                        ARGS.emb_size,
-                                       name='embedding',
-                                       embeddings_constraint=embeddings_constraint)(codes)
+                                       name='embedding')(codes)
         codes_embs = L.Lambda(lambda x: K.sum(x, axis=2))(codes_embs_total)
         #Numeric input if needed
         if ARGS.numeric_size:
@@ -182,18 +176,10 @@ def model_create(ARGS):
         #This implementation uses Bidirectional LSTM instead of reverse order
         #    (see https://github.com/mp2893/retain/issues/3 for more details)
 
-
-        #If training on GPU and Tensorflow use CuDNNLSTM for much faster training
-        if glist:
-            alpha = L.Bidirectional(L.CuDNNLSTM(ARGS.recurrent_size, return_sequences=True),
-                                    name='alpha')
-            beta = L.Bidirectional(L.CuDNNLSTM(ARGS.recurrent_size, return_sequences=True),
-                                   name='beta')
-        else:
-            alpha = L.Bidirectional(L.LSTM(ARGS.recurrent_size,
+        alpha = L.Bidirectional(L.LSTM(ARGS.recurrent_size,
                                            return_sequences=True, implementation=2),
                                     name='alpha')
-            beta = L.Bidirectional(L.LSTM(ARGS.recurrent_size,
+        beta = L.Bidirectional(L.LSTM(ARGS.recurrent_size,
                                           return_sequences=True, implementation=2),
                                    name='beta')
 
@@ -229,18 +215,11 @@ def model_create(ARGS):
 
     #Set Tensorflow to grow GPU memory consumption instead of grabbing all of it at once
     K.clear_session()
-    config = tf.ConfigProto(allow_soft_placement=True, log_device_placement=False)
+    config = tf.compat.v1.ConfigProto(allow_soft_placement=True, log_device_placement=False)
     config.gpu_options.allow_growth = True
-    tfsess = tf.Session(config=config)
-    K.set_session(tfsess)
-    #If there are multiple GPUs set up a multi-gpu model
-    glist = get_available_gpus()
-    if len(glist) > 1:
-        with tf.device('/cpu:0'):
-            model = retain(ARGS)
-        model_final = make_parallel(model, glist)
-    else:
-        model_final = retain(ARGS)
+    tfsess = tf.compat.v1.Session(config=config)
+    tf.compat.v1.keras.backend.set_session(tfsess)
+    model_final = retain(ARGS)
 
     #Compile the model - adamax has produced best results in our experiments
     model_final.compile(optimizer='adamax', loss='binary_crossentropy', metrics=['accuracy'],


### PR DESCRIPTION
This PR upgrades TF1 imports -> TF2 and updates documentation accordingly. Unfortunately, since the `keras_exp` package depends on TF1, I've removed this functionality. I will open a subsequent PR for [TF2 distributed GPU training](https://www.tensorflow.org/guide/distributed_training). Also, I've added a hot fix by removing the `embedding_constraint` variable in the Embedding Layer (see [issue 15](https://github.com/Optum/retain-keras/issues/15#issue-668659440) for more info), but hopefully that can be fixed soon as well. 